### PR TITLE
fix Article router url from id to slug which follow the API spec.

### DIFF
--- a/lib/real_world/blog/article.ex
+++ b/lib/real_world/blog/article.ex
@@ -14,3 +14,9 @@ defmodule RealWorld.Blog.Article do
     timestamps inserted_at: :created_at
   end
 end
+
+defimpl Phoenix.Param, for: RealWorld.Blog.Article do
+  def to_param(%{slug: slug}) do
+    slug
+  end
+end

--- a/lib/real_world/blog/blog.ex
+++ b/lib/real_world/blog/blog.ex
@@ -37,6 +37,23 @@ defmodule RealWorld.Blog do
   """
   def get_article!(id), do: Repo.get!(Article, id)
 
+
+  @doc """
+  Gets a single article with slug
+
+  Raises `Ecto.NoResultsError` if the Article does not exist.
+
+  ## Examples
+
+  iex> get_article_by_slug!(how-to-train-your-dragon)
+  %Article{}
+
+  iex> get_article_by_slug!(how-to-train-your-dragon)
+  ** (Ecto.NoResultsError)
+
+  """
+  def get_article_by_slug!(slug), do: Repo.get_by! Article, slug: slug
+
   @doc """
   Creates a article.
 

--- a/lib/real_world/web/controllers/article_controller.ex
+++ b/lib/real_world/web/controllers/article_controller.ex
@@ -20,21 +20,21 @@ defmodule RealWorld.Web.ArticleController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    article = Blog.get_article!(id)
+  def show(conn, %{"slug" => slug}) do
+    article = Blog.get_article_by_slug! slug
     render(conn, "show.json", article: article)
   end
 
-  def update(conn, %{"id" => id, "article" => article_params}) do
-    article = Blog.get_article!(id)
+  def update(conn, %{"slug" => slug, "article" => article_params}) do
+    article = Blog.get_article_by_slug! slug
 
     with {:ok, %Article{} = article} <- Blog.update_article(article, article_params) do
       render(conn, "show.json", article: article)
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    article = Blog.get_article!(id)
+  def delete(conn, %{"slug" => slug}) do
+    article = Blog.get_article_by_slug! slug
     with {:ok, %Article{}} <- Blog.delete_article(article) do
       send_resp(conn, :no_content, "")
     end

--- a/lib/real_world/web/router.ex
+++ b/lib/real_world/web/router.ex
@@ -10,7 +10,7 @@ defmodule RealWorld.Web.Router do
   scope "/api", RealWorld.Web do
     pipe_through :api
 
-    resources "/articles", ArticleController, except: [:new, :edit]
+    resources "/articles", ArticleController, except: [:new, :edit], param: "slug"
 
     get "/user", UserController, :current_user
     put "/user", UserController, :update

--- a/test/web/controllers/article_controller_test.exs
+++ b/test/web/controllers/article_controller_test.exs
@@ -3,6 +3,7 @@ defmodule RealWorld.Web.ArticleControllerTest do
 
   alias RealWorld.Blog
   alias RealWorld.Blog.Article
+  alias RealWorld.Repo
 
   @create_attrs %{body: "some body", description: "some description", title: "some title"}
   @update_attrs %{body: "some updated body", description: "some updated description", title: "some updated title"}
@@ -25,8 +26,8 @@ defmodule RealWorld.Web.ArticleControllerTest do
   test "creates article and renders article when data is valid", %{conn: conn} do
     conn = post conn, article_path(conn, :create), article: @create_attrs
     assert %{"id" => id} = json_response(conn, 201)["article"]
-
-    conn = get conn, article_path(conn, :show, id)
+    article = Repo.get! Article, id
+    conn = get conn, article_path(conn, :show, article.slug)
     json = json_response(conn, 200)["article"]
 
     assert json == %{
@@ -49,8 +50,8 @@ defmodule RealWorld.Web.ArticleControllerTest do
     %Article{id: id} = article = fixture(:article)
     conn = put conn, article_path(conn, :update, article), article: @update_attrs
     assert %{"id" => ^id} = json_response(conn, 200)["article"]
-
-    conn = get conn, article_path(conn, :show, id)
+    updated_article = Repo.get! Article, id
+    conn = get conn, article_path(conn, :show, updated_article.slug)
     json = json_response(conn, 200)["article"]
 
     assert json == %{


### PR DESCRIPTION
the API spec is using `slug` in url instead of `id`. https://github.com/gothinkster/realworld/tree/master/api#get-article

That's why I made this fix and updated test accordingly